### PR TITLE
feat: Release API v2

### DIFF
--- a/store_api/README.md
+++ b/store_api/README.md
@@ -1,7 +1,12 @@
 # STORE API
 
+### Version 1
 This API is responsible for managing the store products.
 You can create, read, update and delete products using it.
+
+### Version 2
+This API is responsible for managing the store products, its categories and the sales.
+You can create, read, update and delete products and categories using it, create read and delete sales.
 
 ## Testing locally
 ### Requirements:

--- a/store_api/app/api/v2/routes/categories/create.py
+++ b/store_api/app/api/v2/routes/categories/create.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from app.models.v2.categories import CategoriesSchema
+from app.models.v2.response import ResponseSchema
+import app.api.v2.services.categories.post as service
+
+router = APIRouter()
+
+@router.post('/categories', response_model=ResponseSchema, status_code = 201)
+async def create_category (payload: CategoriesSchema):
+    ''' Create a new product '''
+    new_category = await service.post(payload)
+
+    response_object = {
+        'message': "Category created successfully",
+        'data': {
+            'category_id': new_category
+        }
+    }
+
+    return response_object

--- a/store_api/app/api/v2/routes/categories/delete.py
+++ b/store_api/app/api/v2/routes/categories/delete.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.response import ResponseSchema
+from app.api.v2.services.categories import get as get_service
+from app.api.v2.services.categories import delete as delete_service
+
+router = APIRouter()
+
+@router.delete('/categories/{category_id}',response_model=ResponseSchema, status_code = 200)
+async def delete_category (category_id: int):
+    ''' Delete a category from the database '''
+    if category_id < 1:
+        raise HTTPException (
+            status_code = 400,
+            detail = "The category id must be greater than 0"
+        )
+
+    category =  await get_service.get(category_id)
+
+    if not category:
+        raise HTTPException (
+            status_code = 404,
+            detail = "Category not found"
+        )
+
+    deleted_category = await delete_service.delete(category_id)
+
+    response_object = {
+        'message': "Category deleted successfully",
+        'data': {
+            'category_id': deleted_category
+        }
+    }
+
+    return response_object
+    

--- a/store_api/app/api/v2/routes/categories/get.py
+++ b/store_api/app/api/v2/routes/categories/get.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.categories import CategoriesSchemaId
+import app.api.v2.services.categories.get as service
+
+
+router = APIRouter()
+
+@router.get('/categories/{category_id}', response_model=CategoriesSchemaId, status_code = 200)
+async def get_category_by_id(category_id: int):
+    ''' Get an especific existent product by its ID'''
+    if category_id < 1:
+        raise HTTPException(status_code=400, detail="Category ID must be greater than 0")
+
+    category = await service.get(category_id)
+
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+
+    return category

--- a/store_api/app/api/v2/routes/categories/get_all.py
+++ b/store_api/app/api/v2/routes/categories/get_all.py
@@ -1,0 +1,14 @@
+from typing import List
+from fastapi import APIRouter
+from app.models.v2.categories import CategoriesSchemaId
+from app.api.v2.services.categories import get_all as service
+
+router = APIRouter()
+
+@router.get('/categories', response_model=List[CategoriesSchemaId], status_code = 200)
+async def get_all_categories ():
+    ''' Get all categories from the database '''
+    categories = await service.get_all()
+
+    return categories
+    

--- a/store_api/app/api/v2/routes/categories/main.py
+++ b/store_api/app/api/v2/routes/categories/main.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from app.api.v2.routes.categories import create as create_category
+from app.api.v2.routes.categories import get as get_category
+from app.api.v2.routes.categories import get_all as get_all_categories
+from app.api.v2.routes.categories import update as update_category
+from app.api.v2.routes.categories import delete as delete_category
+
+router = APIRouter(
+    tags=["categories"]
+)
+
+router.include_router(create_category.router)
+router.include_router(get_category.router)
+router.include_router(get_all_categories.router)
+router.include_router(update_category.router)
+router.include_router(delete_category.router)

--- a/store_api/app/api/v2/routes/categories/update.py
+++ b/store_api/app/api/v2/routes/categories/update.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.response import ResponseSchema
+from app.models.v2.categories import CategoriesSchema
+from app.api.v2.services.categories import put as put_service
+from app.api.v2.services.categories import get as get_service
+
+router = APIRouter()
+
+@router.put('/categories/{category_id}', response_model = ResponseSchema, status_code = 202)
+async def update_category (category_id: int, payload: CategoriesSchema):
+    ''' Update category on the database '''
+    if category_id < 1:
+        raise HTTPException(status_code=400, detail="Category ID must be greater than 0")
+
+    category = await get_service.get(category_id)
+
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+
+    category = await put_service.put(category_id, payload)
+
+    response_object = {
+        'message': "Category updated successfully",
+        'data': {
+            'cagetory_id': category
+        }
+    }
+
+    return response_object
+    

--- a/store_api/app/api/v2/routes/main.py
+++ b/store_api/app/api/v2/routes/main.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter
 from app.api.v2.routes.products import main as products_routes
-from app.api.v2.routes.sales import main as sales_routes
 from app.api.v2.routes.categories import main as categories_routes
 
 router = APIRouter(
@@ -9,5 +8,4 @@ router = APIRouter(
 )
 
 router.include_router(products_routes.router)
-router.include_router(sales_routes.router)
 router.include_router(categories_routes.router)

--- a/store_api/app/api/v2/routes/main.py
+++ b/store_api/app/api/v2/routes/main.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from app.api.v2.routes.products import main as products_routes
+from app.api.v2.routes.sales import main as sales_routes
+from app.api.v2.routes.categories import main as categories_routes
+
+router = APIRouter(
+    prefix='/v2',
+    tags=["v2"]
+)
+
+router.include_router(products_routes.router)
+router.include_router(sales_routes.router)
+router.include_router(categories_routes.router)

--- a/store_api/app/api/v2/routes/products/create.py
+++ b/store_api/app/api/v2/routes/products/create.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.products import ProductSchema
+from app.models.v2.response import ResponseSchema
+import app.api.v2.services.products.post as service
+import app.api.v2.services.categories.get as categories_service
+
+router = APIRouter()
+
+@router.post('/products', response_model=ResponseSchema, status_code = 201)
+async def create_product (payload: ProductSchema):
+    ''' Create a new product '''
+    category = await categories_service.get(payload.category_id)
+
+    if not category:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Category not found"
+        )
+
+    new_product = await service.post(payload)
+
+    response_object = {
+        'message': "Product created successfully",
+        'data': {
+            'product_id': new_product
+        }
+    }
+
+    return response_object

--- a/store_api/app/api/v2/routes/products/delete.py
+++ b/store_api/app/api/v2/routes/products/delete.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.response import ResponseSchema
+import app.api.v2.services.products.get as get_service
+import app.api.v2.services.products.delete as delete_service
+
+router = APIRouter()
+
+@router.delete('/products/{product_id}', response_model=ResponseSchema, status_code=200)
+async def delete_product(product_id: int):
+    ''' Delete existing product from the database '''
+    if product_id < 1:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Product ID must be greater than 0"
+        )
+
+    product = await get_service.get(product_id)
+
+    if not product:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Product not found"
+        )
+
+    deleted_product = await delete_service.delete(product_id)
+
+    response_object = {
+        'message': "Product deleted successfully",
+        'data': {
+            'product_id': deleted_product
+        }
+    }
+
+    return response_object

--- a/store_api/app/api/v2/routes/products/get.py
+++ b/store_api/app/api/v2/routes/products/get.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.products import CompleteProductSchema
+import app.api.v2.services.products.get as service
+
+
+router = APIRouter()
+
+@router.get('/products/{product_id}', response_model=CompleteProductSchema, status_code = 200)
+async def get_product_by_id(product_id: int):
+    ''' Get an especific existent product by its ID'''
+    if product_id < 1:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Product ID must be greater than 0"
+        )
+
+    product = await service.get(product_id)
+
+    if not product:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Product not found"
+        )
+
+    return product

--- a/store_api/app/api/v2/routes/products/get_all.py
+++ b/store_api/app/api/v2/routes/products/get_all.py
@@ -1,0 +1,15 @@
+from typing import List
+from fastapi import APIRouter
+from app.models.v2.products import CompleteProductSchema
+import app.api.v2.services.products.get_all as service
+
+router = APIRouter()
+
+@router.get('/products', response_model=List[CompleteProductSchema], status_code = 200)
+async def get_all_products(
+    category: int = None
+):
+    ''' List all existent products '''
+    products = await service.get_all(category = category)
+
+    return products

--- a/store_api/app/api/v2/routes/products/main.py
+++ b/store_api/app/api/v2/routes/products/main.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from app.api.v2.routes.products import create as create_product
+from app.api.v2.routes.products import update as update_product
+from app.api.v2.routes.products import delete as delete_product
+from app.api.v2.routes.products import get as get_product
+from app.api.v2.routes.products import get_all as get_all_products
+
+router = APIRouter(
+    tags=["products"]
+)
+
+router.include_router(create_product.router)
+router.include_router(get_all_products.router)
+router.include_router(get_product.router)
+router.include_router(update_product.router)
+router.include_router(delete_product.router)

--- a/store_api/app/api/v2/routes/products/update.py
+++ b/store_api/app/api/v2/routes/products/update.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.products import ProductSchema
+from app.models.v2.response import ResponseSchema
+import app.api.v2.services.products.get as get_service
+import app.api.v2.services.products.put as put_service
+import app.api.v2.services.categories.get as categories_service
+
+router = APIRouter()
+
+@router.put('/products/{product_id}', response_model=ResponseSchema, status_code = 202)
+async def update_product(product_id: int, payload: ProductSchema):
+    ''' Update existent product by its ID '''
+    if product_id < 1:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Product ID must be greater than 0"
+        )
+
+    product = await get_service.get(product_id)
+
+    if not product:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Product not found"
+        )
+
+    category = await categories_service.get(payload.category_id)
+
+    if not category:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Category not found"
+        )
+
+    product = await put_service.put(product_id, payload)
+
+    response_object = {
+        'message': "Product updated successfully",
+        'data': {
+            'product_id': product
+        }
+    }
+
+    return response_object
+    

--- a/store_api/app/api/v2/routes/sales/create.py
+++ b/store_api/app/api/v2/routes/sales/create.py
@@ -8,7 +8,10 @@ router = APIRouter()
 
 @router.post('/sales', response_model=ResponseSchema, status_code=202)
 async def create_sale (payload: SalesSchema):
-    ''' Create a new sale '''
+    ''' Create a new sale \n
+        The valid_for field is the number of days a sale is valid.
+        For a lifetime sale, ignore this field or set its value to 0
+    '''
     product = await products_service.get(payload.product_id)
 
     if not product:

--- a/store_api/app/api/v2/routes/sales/create.py
+++ b/store_api/app/api/v2/routes/sales/create.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.sales import SalesSchema
+from app.models.v2.response import ResponseSchema
+from app.api.v2.services.sales import post as service
+from app.api.v2.services.products import get as products_service
+
+router = APIRouter()
+
+@router.post('/sales', response_model=ResponseSchema, status_code=202)
+async def create_sale (payload: SalesSchema):
+    ''' Create a new sale '''
+    product = await products_service.get(payload.product_id)
+
+    if not product:
+        raise HTTPException (
+            status_code = 404,
+            detail = "Product not found"
+        )
+
+    new_sale = await service.post(payload)
+
+    response_object = {
+        'message': "Sale created successfully",
+        'data': {
+            'sale_id': new_sale
+        }
+    }
+
+    return response_object

--- a/store_api/app/api/v2/routes/sales/delete.py
+++ b/store_api/app/api/v2/routes/sales/delete.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+from app.models.v2.response import ResponseSchema
+from app.api.v2.services.sales import delete as delete_service
+from app.api.v2.services.sales import get as get_service
+
+router = APIRouter()
+
+@router.delete('/sales/{sale_id}', response_model=ResponseSchema, status_code = 200)
+async def delete_sale(sale_id: int):
+    ''' Delete existent sale '''
+    if sale_id < 1:
+        raise HTTPException(
+            status_code = 400,
+            detail = "The sale ID bust be greater than 0"
+        )
+
+    sale = await get_service.get(sale_id)
+
+    if not sale:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Sale not found"
+        )
+
+    deleted_sale = await delete_service.delete(sale_id)
+
+    response_object = {
+        'message': "Sale deleted successfully",
+        'data': {
+            'sale_id': deleted_sale
+        }
+    }
+
+    return response_object

--- a/store_api/app/api/v2/routes/sales/get.py
+++ b/store_api/app/api/v2/routes/sales/get.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, HTTPException
+from app.api.v2.services.sales import get as service
+from app.models.v2.sales import SalesSchemaConsult
+
+router = APIRouter()
+
+@router.get('/sales/{sale_id}', response_model=SalesSchemaConsult, status_code = 200)
+async def get_sale_by_id(sale_id: int):
+    ''' Get an existent sale by its id '''
+    sale = await service.get(sale_id)
+
+    if sale_id < 1:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Sale ID must be greater than 0"
+        )
+
+    sale = await service.get(sale_id)
+
+    if not sale:
+        raise HTTPException(
+            status_code = 404,
+            detail = "Sale not found"
+        )
+
+    return sale

--- a/store_api/app/api/v2/routes/sales/get_all.py
+++ b/store_api/app/api/v2/routes/sales/get_all.py
@@ -12,7 +12,13 @@ async def get_all_sales(
     client: int = None,
     payment_method: int = None
 ):
-    ''' List all existent sales '''
+    ''' List all existent sales \n
+        The sales can be filter by: \n
+        category: Product category id \n
+        product: Product id \n
+        payment_method: Payment method id \n
+        client: Client id \n
+    '''
     sales = await service.get_all(
         category = category,
         product = product,

--- a/store_api/app/api/v2/routes/sales/get_all.py
+++ b/store_api/app/api/v2/routes/sales/get_all.py
@@ -1,0 +1,23 @@
+from typing import List
+from fastapi import APIRouter
+from app.models.v2.sales import SalesSchemaConsult
+import app.api.v2.services.sales.get_all as service
+
+router = APIRouter()
+
+@router.get('/sales', response_model=List[SalesSchemaConsult], status_code = 200)
+async def get_all_sales(
+    category: int = None,
+    product: int = None,
+    client: int = None,
+    payment_method: int = None
+):
+    ''' List all existent sales '''
+    sales = await service.get_all(
+        category = category,
+        product = product,
+        client = client,
+        payment_method = payment_method
+    )
+
+    return sales

--- a/store_api/app/api/v2/routes/sales/main.py
+++ b/store_api/app/api/v2/routes/sales/main.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter
+from app.api.v2.routes.sales import create as create_sale
+from app.api.v2.routes.sales import get_all as get_all_sales
+from app.api.v2.routes.sales import get as get_sales
+from app.api.v2.routes.sales import delete as delete_sales
+
+router = APIRouter(
+    tags=["sales"]
+)
+
+router.include_router(create_sale.router)
+router.include_router(get_all_sales.router)
+router.include_router(get_sales.router)
+router.include_router(delete_sales.router)

--- a/store_api/app/api/v2/services/categories/delete.py
+++ b/store_api/app/api/v2/services/categories/delete.py
@@ -1,0 +1,43 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import func
+from app.database.db import database, categories
+from app.api.v2.services.products import get_all as service
+
+async def delete(category_id: int):
+    ''' Delete existing product in the database '''
+    used_category = await service.get_all(category = category_id)
+
+    if len(used_category) == 0:
+        query = (
+            categories
+            .update()
+            .where(categories.c.id == category_id)
+            .values(
+                deleted_at = func.now()
+            )
+            .returning(categories.c.id)
+        )
+    else:
+        query = (
+            categories
+            .update()
+            .where(categories.c.id == category_id)
+            .values(
+                inactivated_at = func.now()
+            )
+            .returning(categories.c.id)
+        )
+
+    try:
+        await database.connect()
+        deleted_category = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return deleted_category
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while deleting category from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/categories/get.py
+++ b/store_api/app/api/v2/services/categories/get.py
@@ -1,0 +1,27 @@
+from fastapi import HTTPException
+from app.database.db import database, categories
+
+async def get(category_id: int):
+    ''' Get existent category by id '''
+    query = (
+        categories
+        .select()
+        .where(
+            categories.c.id == category_id,
+            categories.c.deleted_at.is_(None),
+            categories.c.inactivated_at.is_(None),
+        )
+    )
+
+    try:
+        await database.connect()
+        category = await database.fetch_one(query = query)
+
+        await database.disconnect()
+
+        return category
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching category from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/categories/get_all.py
+++ b/store_api/app/api/v2/services/categories/get_all.py
@@ -1,0 +1,27 @@
+from app.database.db import database, categories
+from fastapi import HTTPException
+
+async def get_all():
+    ''' Get all existent categories from the database '''
+    query = (
+        categories
+        .select()
+        .where(
+            categories.c.deleted_at.is_(None),
+            categories.c.inactivated_at.is_(None)
+        )
+    )
+
+    try:
+        await database.connect()
+        found_category = await database.fetch_all(query = query)
+
+        await database.disconnect()
+
+        return found_category
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching categories from database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/categories/post.py
+++ b/store_api/app/api/v2/services/categories/post.py
@@ -1,0 +1,24 @@
+from app.database.db import database, categories
+from app.models.v2.categories import CategoriesSchema
+from fastapi import HTTPException
+
+async def post(category: CategoriesSchema):
+    ''' Insert the category into the database '''
+    query = categories.insert().values(
+        name = category.name,
+        description = category.description,
+    )
+
+    try:
+        await database.connect()
+        new_category = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return new_category
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while creating category on the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/categories/put.py
+++ b/store_api/app/api/v2/services/categories/put.py
@@ -1,0 +1,32 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import func
+from app.database.db import database, categories
+from app.models.v2.categories import CategoriesSchema
+
+async def put(category_id: int, product: CategoriesSchema):
+    ''' Update existing product in the database '''
+    query = (
+        categories
+        .update()
+        .where(categories.c.id == category_id)
+        .values(
+            name = product.name,
+            description = product.description,
+            updated_at = func.now()
+        )
+        .returning(categories.c.id)
+    )
+
+    try:
+        await database.connect()
+        updated_category = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return updated_category
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while updating category on the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/products/delete.py
+++ b/store_api/app/api/v2/services/products/delete.py
@@ -1,0 +1,43 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import func
+from app.database.db import database, products
+from app.api.v2.services.sales import get_all as service
+
+async def delete(product_id: int):
+    ''' Delete existing product in the database '''
+    sold_product = await service.get_all(product = product_id)
+
+    if len(sold_product) == 0:
+        query = (
+            products
+            .update()
+            .where(products.c.id == product_id)
+            .values(
+                deleted_at = func.now()
+            )
+            .returning(products.c.id)
+        )
+    else:
+        query = (
+            products
+            .update()
+            .where(products.c.id == product_id)
+            .values(
+                inactivated_at = func.now()
+            )
+            .returning(products.c.id)
+        )
+
+    try:
+        await database.connect()
+        deleted_product = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return deleted_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while deleting product from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/products/get.py
+++ b/store_api/app/api/v2/services/products/get.py
@@ -1,0 +1,36 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import select
+from app.database.db import database, products, categories
+
+async def get(product_id: int):
+    ''' Get existent product by id '''
+    query = (
+        select([
+            products.c.name,
+            products.c.id,
+            products.c.description,
+            products.c.price,
+            products.c.image,
+            products.c.category_id,
+            categories.c.name.label('category')
+        ])
+        .where(
+            products.c.id == product_id,
+            products.c.deleted_at.is_(None),
+            products.c.inactivated_at.is_(None),
+            products.c.category_id == categories.c.id
+        )
+    )
+
+    try:
+        await database.connect()
+        product = await database.fetch_one(query = query)
+
+        await database.disconnect()
+
+        return product
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching product from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/products/get_all.py
+++ b/store_api/app/api/v2/services/products/get_all.py
@@ -1,0 +1,43 @@
+from app.database.db import database, products, categories
+from fastapi import HTTPException
+from sqlalchemy.sql import select
+
+async def get_all(
+    category: int = None
+):
+    ''' Get all existent products from the database '''
+    query = (
+        select(
+            [
+                products.c.name,
+                products.c.price,
+                products.c.description,
+                products.c.id,
+                products.c.image,
+                products.c.category_id,
+                categories.c.name.label('category')
+            ]
+        )
+        .where(
+            products.c.deleted_at.is_(None),
+            products.c.inactivated_at.is_(None),
+            products.c.category_id == categories.c.id
+        )
+    )
+
+    if category is not None:
+        query.append_whereclause(products.c.category_id == category)
+
+    try:
+        await database.connect()
+        found_product = await database.fetch_all(query = query)
+
+        await database.disconnect()
+
+        return found_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching products from database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/products/get_all.py
+++ b/store_api/app/api/v2/services/products/get_all.py
@@ -26,6 +26,12 @@ async def get_all(
     )
 
     if category is not None:
+        if category < 1:
+            raise HTTPException(
+                status_code = 400,
+                detail = "The category filter must be a value greater than zero"
+            )
+
         query.append_whereclause(products.c.category_id == category)
 
     try:

--- a/store_api/app/api/v2/services/products/post.py
+++ b/store_api/app/api/v2/services/products/post.py
@@ -1,0 +1,27 @@
+from app.database.db import database, products
+from app.models.v2.products import ProductSchema
+from fastapi import HTTPException
+
+async def post(product: ProductSchema):
+    ''' Insert the product into the database '''
+    query = products.insert().values(
+        name = product.name,
+        description = product.description,
+        price = product.price,
+        category_id = product.category_id,
+        image = product.image
+    )
+
+    try:
+        await database.connect()
+        new_product = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return new_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while creating product on the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/products/put.py
+++ b/store_api/app/api/v2/services/products/put.py
@@ -1,0 +1,35 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import func
+from app.database.db import database, products
+from app.models.v2.products import ProductSchema
+
+async def put(product_id: int, product: ProductSchema):
+    ''' Update existing product in the database '''
+    query = (
+        products
+        .update()
+        .where(products.c.id == product_id)
+        .values(
+            name = product.name,
+            description = product.description,
+            price = product.price,
+            image = product.image,
+            category_id = product.category_id,
+            updated_at = func.now()
+        )
+        .returning(products.c.id)
+    )
+
+    try:
+        await database.connect()
+        updated_product = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return updated_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while updating product on the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/sales/delete.py
+++ b/store_api/app/api/v2/services/sales/delete.py
@@ -1,0 +1,31 @@
+from fastapi import HTTPException
+from sqlalchemy.sql import func
+from app.database.db import database, sales
+
+async def delete(sale_id: int):
+    ''' Delete existing sale in the database '''
+    query = (
+        sales
+        .update()
+        .where(
+            sales.c.id == sale_id
+        )
+        .values(
+            deleted_at = func.now()
+        )
+        .returning(sales.c.id)
+    )
+
+    try:
+        await database.connect()
+        deleted_product = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return deleted_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code=500,
+            detail=f"An error occurred while deleting sale from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/sales/get.py
+++ b/store_api/app/api/v2/services/sales/get.py
@@ -1,0 +1,26 @@
+from fastapi import HTTPException
+from app.database.db import database, sales
+
+async def get(sale_id: int):
+    ''' Get existent sale by id '''
+    query = (
+        sales
+        .select()
+        .where(
+            sales.c.id == sale_id,
+            sales.c.deleted_at.is_(None),
+        )
+    )
+
+    try:
+        await database.connect()
+        sale = await database.fetch_one(query = query)
+
+        await database.disconnect()
+
+        return sale
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching sale from the database: {err}"
+        ) from err

--- a/store_api/app/api/v2/services/sales/get_all.py
+++ b/store_api/app/api/v2/services/sales/get_all.py
@@ -28,15 +28,37 @@ async def get_all(
     )
 
     if product is not None:
+        if product < 1:
+            raise HTTPException(
+                status_code = 400,
+                detail = "The product filter must be a value greater than zero"
+            )
+
         query.append_whereclause(sales.c.product_id == product)
 
     if payment_method is not None:
+        if payment_method < 1:
+            raise HTTPException(
+                status_code = 400,
+                detail = "The payment method filter must be a value greater than zero"
+            )
         query.append_whereclause(sales.c.payment_method_id == payment_method)
 
     if client is not None:
+        if client < 1:
+            raise HTTPException(
+                status_code = 400,
+                detail = "The client filter must be a value greater than zero"
+            )
         query.append_whereclause(sales.c.client_id == client)
 
     if category is not None:
+        if category < 1:
+            raise HTTPException(
+                status_code = 400,
+                detail = "The category filter must be a value greater than zero"
+            )
+
         query.append_whereclause(sales.c.product_id == products.c.id)
         query.append_whereclause(products.c.category_id == category)
 

--- a/store_api/app/api/v2/services/sales/get_all.py
+++ b/store_api/app/api/v2/services/sales/get_all.py
@@ -1,0 +1,55 @@
+from fastapi import HTTPException
+from app.database.db import database, sales, products
+from sqlalchemy.sql import select
+
+async def get_all(
+    product: int = None,
+    category: int = None,
+    payment_method: int = None,
+    client: int = None
+):
+    ''' Get all existent sales from the database '''
+    query = (
+        select(
+            [
+                sales.c.id,
+                sales.c.client_id,
+                sales.c.product_id,
+                sales.c.payment_method_id,
+                sales.c.amount,
+                sales.c.price,
+                sales.c.valid_until,
+                sales.c.created_at
+            ]
+        )
+        .where(
+            sales.c.deleted_at.is_(None),
+        )
+    )
+
+    if product is not None:
+        query.append_whereclause(sales.c.product_id == product)
+
+    if payment_method is not None:
+        query.append_whereclause(sales.c.payment_method_id == payment_method)
+
+    if client is not None:
+        query.append_whereclause(sales.c.client_id == client)
+
+    if category is not None:
+        query.append_whereclause(sales.c.product_id == products.c.id)
+        query.append_whereclause(products.c.category_id == category)
+
+    try:
+        await database.connect()
+        found_product = await database.fetch_all(query = query)
+
+        await database.disconnect()
+
+        return found_product
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code = 500,
+            detail = f"An error occurred while fetching sales from database: {query}"
+        ) from err

--- a/store_api/app/api/v2/services/sales/post.py
+++ b/store_api/app/api/v2/services/sales/post.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta
+from fastapi import HTTPException
+from app.database.db import database, sales
+from app.models.v2.sales import SalesSchema
+
+async def post (sale: SalesSchema):
+    ''' Insert the sale into the database '''
+
+    end_date = datetime or None
+
+    if sale.valid_for != 0:
+        end_date = datetime.now() + timedelta(days = sale.valid_for)
+    else:
+        end_date = None
+
+    query = (
+        sales
+        .insert()
+        .values(
+            client_id = sale.client_id,
+            product_id = sale.product_id,
+            payment_method_id = sale.payment_method_id,
+            amount = sale.amount,
+            price = sale.price,
+            valid_until = end_date
+        )
+    )
+
+    try:
+        await database.connect()
+
+        sale_id = await database.execute(query = query)
+
+        await database.disconnect()
+
+        return sale_id
+
+    except AssertionError as err:
+        raise HTTPException(
+            status_code=500,
+            detail=f'An error occurred while creating sale on the database: {err}'
+        ) from err

--- a/store_api/app/api/v2/services/sales/post.py
+++ b/store_api/app/api/v2/services/sales/post.py
@@ -8,7 +8,7 @@ async def post (sale: SalesSchema):
 
     end_date = datetime or None
 
-    if sale.valid_for != 0:
+    if sale.valid_for != 0 and sale.valid_for is not None:
         end_date = datetime.now() + timedelta(days = sale.valid_for)
     else:
         end_date = None

--- a/store_api/app/database/db.py
+++ b/store_api/app/database/db.py
@@ -64,7 +64,7 @@ products = Table (
 
 # define table sales
 sales = Table(
-    'sales',
+    'store_sales',
     metadata,
     Column('id', Integer, primary_key=True),
     Column('client_id', Integer, nullable=False),

--- a/store_api/app/database/db.py
+++ b/store_api/app/database/db.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     Float,
+    ForeignKey,
     Integer,
     String,
     Table,
@@ -32,6 +33,20 @@ if not engine.dialect.has_schema(engine, DB_SCHEMA):
 
 metadata = MetaData(schema=DB_SCHEMA) # used for creating the database schema
 
+#define table categories
+categories = Table (
+    'categories',
+    metadata,
+    Column('id', Integer, primary_key=True),
+    Column('name', String(30), nullable=False),
+    Column('description', String(140), nullable=True),
+    Column('created_at', DateTime(timezone=True), default=func.now(), nullable=False),
+    Column('inactivated_at', DateTime(timezone=True), nullable=True),
+    Column('updated_at', DateTime(timezone=True), nullable=True),
+    Column('updated_at', DateTime(timezone=True), nullable=True),
+    Column('deleted_at', DateTime(timezone=True), nullable=True)
+)
+
 # define table products
 products = Table (
     'products',
@@ -39,14 +54,31 @@ products = Table (
     Column('id', Integer, primary_key=True),
     Column('name', String(50), nullable=False),
     Column('description', String(140), nullable=False),
+    Column('category_id', ForeignKey('categories.id'), nullable=False),
     Column('price', Float, nullable=False),
     Column('image', Text, nullable=True),
     Column('created_at', DateTime(timezone=True), default=func.now(), nullable=False),
+    Column('inactivated_at', DateTime(timezone=True)),
     Column('updated_at', DateTime(timezone=True)),
     Column('deleted_at', DateTime(timezone=True)),
 )
 
-# create table products on the database
+# define table sales
+sales = Table(
+    'sales',
+    metadata,
+    Column('id', Integer, primary_key=True),
+    Column('client_id', Integer, nullable=False),
+    Column('product_id', ForeignKey('products.id'), nullable=False),
+    Column('amount', Integer, nullable=False, default=1),
+    Column('payment_method_id', Integer, nullable=False),
+    Column('price', Float, nullable=False),
+    Column('valid_until', DateTime(timezone=True), nullable=True),
+    Column('created_at', DateTime(timezone=True), default=func.now(), nullable=False),
+    Column('deleted_at', DateTime(timezone=True)),
+)
+
+# create tables on the database
 metadata.create_all(engine)
 
 # database query builder

--- a/store_api/app/database/db.py
+++ b/store_api/app/database/db.py
@@ -43,7 +43,6 @@ categories = Table (
     Column('created_at', DateTime(timezone=True), default=func.now(), nullable=False),
     Column('inactivated_at', DateTime(timezone=True), nullable=True),
     Column('updated_at', DateTime(timezone=True), nullable=True),
-    Column('updated_at', DateTime(timezone=True), nullable=True),
     Column('deleted_at', DateTime(timezone=True), nullable=True)
 )
 

--- a/store_api/app/main.py
+++ b/store_api/app/main.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI
-from app.api.v1.routes.products import main as products_routes
+from app.api.v1.routes.products import main as v1_routes
+from app.api.v2.routes import main as v2_routes
 
 app = FastAPI()
 
-app.include_router(products_routes.router)
+app.include_router(v1_routes.router)
+
+app.include_router(v2_routes.router)

--- a/store_api/app/models/v2/categories.py
+++ b/store_api/app/models/v2/categories.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, validator
+
+class CategoriesSchema(BaseModel):
+    ''' Category schema '''
+    name: str
+    description: str
+
+    @validator('name')
+    def validate_name_lenght (cls, name): # pylint: disable=no-self-argument
+        ''' Validate category name  lenght '''
+        if not (len(name) > 2 and len(name) < 31):
+            raise ValueError("Category name must be greater than 2 and smaller than 31 characters")
+
+        return name.capitalize()
+
+    @validator('description')
+    def validate_description_lenght (cls, description): # pylint: disable=no-self-argument
+        ''' Validate category description lenght '''
+        if not (len(description) > 2 and len(description) < 141):
+            raise ValueError("Description must be greater than 2 and smaller than 141 characters")
+
+        return description.capitalize()
+
+class CategoriesSchemaId(CategoriesSchema):
+    ''' Category schema with id '''
+    id: int

--- a/store_api/app/models/v2/products.py
+++ b/store_api/app/models/v2/products.py
@@ -1,0 +1,49 @@
+from typing import Optional
+from pydantic import BaseModel, validator
+
+class ProductSchema (BaseModel):
+    ''' Schema for products '''
+    name: str
+    description: str
+    category_id: int
+    price: float
+    image: Optional[str]
+
+    @validator('name')
+    def name_must_be_greater_than3_and_smaller_than30(cls, name): #pylint: disable=no-self-argument
+        ''' Validate product name lenght '''
+        if not (len(name) > 2 and len(name) < 31):
+            raise ValueError("Product name must be greater than 2 and smaller than 31 characters")
+
+        return name.title()
+
+    @validator('description')
+    def description_must_be_greater_than3_and_smaller_than140(cls, description): #pylint: disable=no-self-argument
+        ''' Validate product description lenght '''
+        if not (len(description) > 2 and len(description) < 141):
+            raise ValueError(
+               "Product description must be greater than 2 and smaller than 141 characters")
+
+        return description.capitalize()
+
+    @validator('price')
+    def price_must_be_positive(cls, price): #pylint: disable=no-self-argument
+        ''' Valiadte price value '''
+        if price < 0:
+            raise ValueError("Price must be positive")
+
+        return float(price)
+
+    @validator('category_id')
+    def category_must_be_greater_than_zero(cls, category): #pylint: disable=no-self-argument
+        ''' Validate category greater than zero '''
+        if category < 1:
+            raise ValueError("Category must be greater than zero")
+
+        return int(category)
+
+# inherit attributes from ProductSchema and add new ones
+class CompleteProductSchema (ProductSchema):
+    ''' Schema for products with ID '''
+    id: int
+    category: str

--- a/store_api/app/models/v2/response.py
+++ b/store_api/app/models/v2/response.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class ResponseSchema (BaseModel):
+    ''' Response schema '''
+    message: str
+    data: dict

--- a/store_api/app/models/v2/sales.py
+++ b/store_api/app/models/v2/sales.py
@@ -1,0 +1,58 @@
+from typing import Optional
+from datetime import datetime
+from pydantic import BaseModel, validator
+
+class SalesSchema(BaseModel):
+    ''' Sales schema '''
+    client_id: int
+    product_id: int
+    payment_method_id: int
+    amount: int
+    price: float
+    valid_for: Optional[int]
+
+    @validator('client_id')
+    def client_it_is_greater_than_zero (cls, client_id): # pylint: disable=no-self-argument
+        ''' Validate client_id greater than zero '''
+        if client_id < 1:
+            raise ValueError('The client_id must be greater than zero')
+        else:
+            return client_id
+
+    @validator('product_id')
+    def product_it_is_greater_than_zero (cls, product_id): # pylint: disable=no-self-argument
+        ''' Validate product_id greater than zero'''
+        if product_id < 1:
+            raise ValueError('The product_id must be greater than zero')
+        else:
+            return product_id
+
+    @validator('payment_method_id')
+    def payment_method_it_is_greater_than_zero(cls, payment_method_id): # pylint: disable=no-self-argument
+        ''' Validate product_id greater than zero '''
+        if payment_method_id < 1:
+            raise ValueError('The payment_method_id must be greater than zero')
+        else:
+            return payment_method_id
+
+    @validator('amount')
+    def amount_is_greater_than_zero (cls, amount): # pylint: disable=no-self-argument
+        ''' Validate amount greater than zero '''
+        if amount < 1:
+            raise ValueError('The amount must be greater than zero')
+        else:
+            return amount
+
+    @validator('price')
+    def price_is_greater_than_zero (cls, price): # pylint: disable=no-self-argument
+        ''' Validate price positive  '''
+        if price < 0:
+            raise ValueError('The price must be positive')
+        else:
+            return float(price)
+
+class SalesSchemaConsult (SalesSchema):
+    ''' Sales schema for consult '''
+    id: int
+    valid_until: Optional[datetime]
+    created_at: datetime

--- a/store_api/tests/api/v1/test_create_product.py
+++ b/store_api/tests/api/v1/test_create_product.py
@@ -42,7 +42,7 @@ def test_create_new_product(monkeypatch, test_app):
     ],
 )
 
-def test_create_new_product_with_invalid_payload(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_payload(test_app, payload, status_code):
     ''' Test creating new product with invalid payload '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -58,7 +58,7 @@ def test_create_new_product_with_invalid_payload(test_app, monkeypatch, payload,
     ],
 )
 
-def test_create_new_product_with_invalid_name(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_name(test_app, payload, status_code):
     ''' Test creating new product with invalid name '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -74,7 +74,7 @@ def test_create_new_product_with_invalid_name(test_app, monkeypatch, payload, st
     ],
 )
 
-def test_create_new_product_with_invalid_description(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_description(test_app, payload, status_code):
     ''' Test creating new product with invalid description '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -90,7 +90,7 @@ def test_create_new_product_with_invalid_description(test_app, monkeypatch, payl
     ],
 )
 
-def test_create_new_product_with_invalid_price(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_price(test_app, payload, status_code):
     ''' Test creating new product with invalid price '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -108,7 +108,7 @@ def test_create_new_product_with_invalid_price(test_app, monkeypatch, payload, s
     ],
 )
 
-def test_create_new_product_with_invalid_name_and_description(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_name_and_description(test_app, payload, status_code):
     ''' Test creating new product with invalid name and description '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -126,7 +126,7 @@ def test_create_new_product_with_invalid_name_and_description(test_app, monkeypa
     ],
 )
 
-def test_create_new_product_with_invalid_name_and_price(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_name_and_price(test_app, payload, status_code):
     ''' Test creating new product with invalid name and price '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))
@@ -144,7 +144,7 @@ def test_create_new_product_with_invalid_name_and_price(test_app, monkeypatch, p
     ],
 )
 
-def test_create_new_product_with_invalid_description_and_price(test_app, monkeypatch, payload, status_code): #pylint: disable=unused-argument
+def test_create_new_product_with_invalid_description_and_price(test_app, payload, status_code):
     ''' Test creating new product with invalid description and price '''
 
     response = test_app.post('/v1/products', data=json.dumps(payload))

--- a/store_api/tests/api/v1/test_update_product.py
+++ b/store_api/tests/api/v1/test_update_product.py
@@ -45,7 +45,7 @@ def test_update_product_by_id(test_app, monkeypatch):
     ]
 )
 
-def test_update_product_with_invalid_id(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_invalid_id(test_app, monkeypatch, product_id, payload, status_code):
     ''' Test update product with invalid id '''
 
     async def mock_get(_):
@@ -72,7 +72,7 @@ def test_update_product_with_invalid_id(test_app, monkeypatch, product_id, paylo
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_payload(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_payload(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid payload '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -88,7 +88,7 @@ def test_update_product_with_valid_id_but_invalid_payload(test_app, monkeypatch,
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_name(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_name(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid name '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -104,7 +104,7 @@ def test_update_product_with_valid_id_but_invalid_name(test_app, monkeypatch, pr
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_description(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_description(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid description '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -120,7 +120,7 @@ def test_update_product_with_valid_id_but_invalid_description(test_app, monkeypa
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_price(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_price(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid price '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -138,7 +138,7 @@ def test_update_product_with_valid_id_but_invalid_price(test_app, monkeypatch, p
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_name_and_description(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_name_and_description(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid name and description '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -156,7 +156,7 @@ def test_update_product_with_valid_id_but_invalid_name_and_description(test_app,
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_name_and_price(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_name_and_price(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid name and price '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))
@@ -174,7 +174,7 @@ def test_update_product_with_valid_id_but_invalid_name_and_price(test_app, monke
     ],
 )
 
-def test_update_product_with_valid_id_but_invalid_description_and_price(test_app, monkeypatch, product_id, payload, status_code): #pylint: disable=unused-argument
+def test_update_product_with_valid_id_but_invalid_description_and_price(test_app, product_id, payload, status_code):
     ''' Test updating new product with invalid description and price '''
 
     response = test_app.put(f'/v1/products/{product_id}', data=json.dumps(payload))


### PR DESCRIPTION
## Description
Release the API version 2. Add two new tables: `categories` and `sales`.
The `get_all` routes for `products` and `sales` accept filters, passed by query string.
The response model has changed.
The attempt to delete a product or category already sold or are in use for an active product will inactivate, not delete, the product or category.

## Changes
- Create `get`,  `get_all`, `post`, `put` and `delete` routes for `categories`
- Create `get`,  `get_all`, `post`, `put` and `delete` routes for `products`
- Create `get`,  `get_all`, `post` and `delete` routes for `sales`
- Filters for the `sales` `get_all` route:
    - `category`: category id 
    - `product`: product id
    - `client`: client id
    - `payment_method`: payment method id
- Filters for the `products` `get_all` route:
    - `category`: category id
- When creating a sale, there is a `valid_for` field. It must specify the period the sale will be valid. Unit measurement: `days`, for a lifetime sale, just ignore this field or send `0`

## Checklist
<!-- ==========================================
>| Read the checklist below and check where your PR applies
========================================== -->

#### Docs:
- [ ] My changes do not require changing README.md
- [x] My changes require changing the README.md and I made the necessary changes.
<!-- - [ ] My changes don't require changing the release notes
≈- [ ] My changes require changes to the release notes and I made the necessary changes -->


### Env vars:
- [x] I didn't add/change any env var
- [ ] I add a new env var
- [ ] I updated an env var
